### PR TITLE
Add newman tests for website and api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /*
 !/config.template/
 !/scripts/
+!/tests/
 !.env.template
 !.gitignore
 !.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,11 @@ script:
   # prepare services under test
   # faf-db first because it takes the longest to load
   - docker-compose up -d faf-db
-  - docker-compose up -d faf-java-api faf-website
-  # wait for db migrations to be run
   - sleep 60
+  - docker-compose up -d faf-java-api
+  - sleep 60
+  - docker-compose up -d faf-website
+  # wait for db migrations to be run
   # insert test data
   - docker exec -i faf-db mysql -uroot -pbanana faf < test-data.sql
   # run test collection

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 
 # Temporarily update docker until travis supports compose v3.3+ files
 before_install:
+  - sudo service mysql stop
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
@@ -13,7 +14,21 @@ before_install:
   - sudo chmod +x /usr/local/bin/docker-compose
   - docker-compose version
 
-script:
+install:
   - cp -r config.template config
+  - cp .env.template .env
+  - wget https://raw.githubusercontent.com/FAForever/db/develop/test-data.sql
+
+script:
   # Causes the docker-compose.yml to be syntax checked, without actually doing anything
   - docker-compose config
+  # prepare services under test
+  # faf-db first because it takes the longest to load
+  - docker-compose up -d faf-db
+  - docker-compose up -d faf-java-api faf-website
+  # wait for db migrations to be run
+  - sleep 60
+  # insert test data
+  - docker exec -i faf-db mysql -uroot -pbanana faf < test-data.sql
+  # run test collection
+  - docker run --network="host" -t postman/newman_ubuntu1404 run https://raw.githubusercontent.com/FAForever/faf-stack/${TRAVIS_BRANCH}/tests/postman-collection.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
   #
   faf-java-api:
     container_name: faf-java-api
-    image: faforever/faf-java-api:v2.0.5
+    image: faforever/faf-java-api:v2.1.0
     user: ${FAF_JAVA_API_USER}
     networks:
       faf:

--- a/tests/postman-collection.json
+++ b/tests/postman-collection.json
@@ -6,37 +6,204 @@
 	},
 	"item": [
 		{
-			"name": "Main Website",
-			"event": [
+			"name": "website",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"id": "9c524ab4-9a1d-427a-88e7-3085f1025c33",
-						"type": "text/javascript",
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Body matches string\", function () {",
-							"    pm.expect(pm.response.text()).to.include(\"Forged Alliance Forever\");",
-							"});"
-						]
-					}
+					"name": "main website",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9c524ab4-9a1d-427a-88e7-3085f1025c33",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Body matches string\", function () {",
+									"    pm.expect(pm.response.text()).to.include(\"Forged Alliance Forever\");",
+									"});"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {},
+						"url": {
+							"raw": "{{website-url}}",
+							"host": [
+								"{{website-url}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "register (fail - username in use)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5b42d51e-5a51-4785-a3d1-cd5e8a461e2f",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Body matches string\", function () {",
+									"    pm.expect(pm.response.text()).to.include(\"The entered username is already in use: test\");",
+									"});"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "username",
+									"value": "test",
+									"type": "text"
+								},
+								{
+									"key": "email",
+									"value": "test@test.test",
+									"type": "text"
+								},
+								{
+									"key": "password",
+									"value": "123456",
+									"type": "text"
+								},
+								{
+									"key": "password_confirm",
+									"value": "123456",
+									"type": "text"
+								},
+								{
+									"key": "tosagree",
+									"value": "on",
+									"type": "text"
+								},
+								{
+									"key": "privacyagree",
+									"value": "on",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{website-url}}/account/register",
+							"host": [
+								"{{website-url}}"
+							],
+							"path": [
+								"account",
+								"register"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "confirm registration",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b76596b6-8676-43c3-a807-ff84f9c5420a",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Body matches string\", function () {",
+									"    pm.expect(pm.response.text()).to.include(\"You have activated your account successfully!\");",
+									"});"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "username",
+									"value": "new_user",
+									"type": "text"
+								},
+								{
+									"key": "email",
+									"value": "new@user.email",
+									"type": "text"
+								},
+								{
+									"key": "password",
+									"value": "123456",
+									"type": "text"
+								},
+								{
+									"key": "password_confirm",
+									"value": "123456",
+									"type": "text"
+								},
+								{
+									"key": "tosagree",
+									"value": "on",
+									"type": "text"
+								},
+								{
+									"key": "privacyagree",
+									"value": "on",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{api-url}}/users/activate?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsaWZldGltZSI6IjIwNTAtMTItMzFUMTk6MzY6MTguMjIzWiIsImFjdGlvbiI6IlJFR0lTVFJBVElPTiIsInBhc3N3b3JkIjoiOGQ5NjllZWY2ZWNhZDNjMjlhM2E2MjkyODBlNjg2Y2YwYzNmNWQ1YTg2YWZmM2NhMTIwMjBjOTIzYWRjNmM5MiIsImVtYWlsIjoibmV3QHVzZXIuZW1haWwiLCJ1c2VybmFtZSI6Im5ld191c2VyIn0.nZblUmo96ryd_P0T8E4Q28AHqrpKcfVjLxTTXD7Xp1s",
+							"host": [
+								"{{api-url}}"
+							],
+							"path": [
+								"users",
+								"activate"
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsaWZldGltZSI6IjIwNTAtMTItMzFUMTk6MzY6MTguMjIzWiIsImFjdGlvbiI6IlJFR0lTVFJBVElPTiIsInBhc3N3b3JkIjoiOGQ5NjllZWY2ZWNhZDNjMjlhM2E2MjkyODBlNjg2Y2YwYzNmNWQ1YTg2YWZmM2NhMTIwMjBjOTIzYWRjNmM5MiIsImVtYWlsIjoibmV3QHVzZXIuZW1haWwiLCJ1c2VybmFtZSI6Im5ld191c2VyIn0.nZblUmo96ryd_P0T8E4Q28AHqrpKcfVjLxTTXD7Xp1s"
+								}
+							]
+						}
+					},
+					"response": []
 				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"body": {},
-				"url": {
-					"raw": "{{website-url}}",
-					"host": [
-						"{{website-url}}"
-					]
-				}
-			},
-			"response": []
+			]
+		},
+		{
+			"name": "api",
+			"item": []
 		}
 	],
 	"event": [
@@ -63,9 +230,15 @@
 	],
 	"variable": [
 		{
-			"id": "29729c24-2edd-4e71-a054-22540afa89d3",
+			"id": "885a2e70-ec90-4879-aa53-490f03ff721d",
 			"key": "website-url",
 			"value": "http://localhost:8020",
+			"type": "string"
+		},
+		{
+			"id": "5982e588-93c6-4486-b6ab-388fc87ebaca",
+			"key": "api-url",
+			"value": "http://localhost:8010",
 			"type": "string"
 		}
 	]

--- a/tests/postman-collection.json
+++ b/tests/postman-collection.json
@@ -1,0 +1,72 @@
+{
+	"info": {
+		"_postman_id": "80efcc1b-8473-4739-89b9-db2e75fc8871",
+		"name": "FAF-Stack Test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Main Website",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "9c524ab4-9a1d-427a-88e7-3085f1025c33",
+						"type": "text/javascript",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Body matches string\", function () {",
+							"    pm.expect(pm.response.text()).to.include(\"Forged Alliance Forever\");",
+							"});"
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {},
+				"url": {
+					"raw": "{{website-url}}",
+					"host": [
+						"{{website-url}}"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "7c9450d1-de20-4bf0-9bce-2b6672946e9e",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "90e0e0f8-43b6-4b37-a68c-c048d21031c9",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"id": "29729c24-2edd-4e71-a054-22540afa89d3",
+			"key": "website-url",
+			"value": "http://localhost:8020",
+			"type": "string"
+		}
+	]
+}

--- a/tests/postman-collection.json
+++ b/tests/postman-collection.json
@@ -203,7 +203,41 @@
 		},
 		{
 			"name": "api",
-			"item": []
+			"item": [
+				{
+					"name": "main api page (swagger)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "90041ffc-4c75-434e-a36c-21b79684fc61",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Body matches string\", function () {",
+									"    pm.expect(pm.response.text()).to.include(\"Swagger UI\");",
+									"});"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {},
+						"url": {
+							"raw": "{{api-url}}",
+							"host": [
+								"{{api-url}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"event": [
@@ -230,13 +264,13 @@
 	],
 	"variable": [
 		{
-			"id": "885a2e70-ec90-4879-aa53-490f03ff721d",
+			"id": "32a56849-43f4-437e-9671-c7d5658a4034",
 			"key": "website-url",
 			"value": "http://localhost:8020",
 			"type": "string"
 		},
 		{
-			"id": "5982e588-93c6-4486-b6ab-388fc87ebaca",
+			"id": "b05b095e-aadd-4d26-b483-864f1e87d9d9",
 			"key": "api-url",
 			"value": "http://localhost:8010",
 			"type": "string"


### PR DESCRIPTION
This PR will allow us to check the correct setup of core services like API and website.

Remaining task:
- [x] Test registration in website
- [ ] Test registration in API
- [ ] Test registration token confirmation in API
- [ ] Test some core vault queries in API
- [ ] Test leaderboard queries in API

However I would rather this merged first, as in the current state it already ensures that the apps can actually take connections.