### PR TITLE
Update grafana and prometheus to latest versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -235,7 +235,7 @@ services:
   #
   faf-prometheus:
     container_name: faf-prometheus
-    image: prom/prometheus:v1.7.2
+    image: prom/prometheus:v2.11.1
     user: ${FAF_PROMETHEUS_USER}
     restart: unless-stopped
     env_file: ./config/faf-prometheus/faf-prometheus.env
@@ -258,7 +258,7 @@ services:
   #
   faf-grafana:
     container_name: faf-grafana
-    image: grafana/grafana:4.5.1
+    image: grafana/grafana:6.2.5
     restart: unless-stopped
     networks:
       - "faf"


### PR DESCRIPTION
On the test server, prometheus was able to update and start without issue. Grafana tries to create files, but because `data/faf-grafana` is owned by FAForever it cannot create any new files. Db migrations or actions that only need to modify the existing files seem to complete correctly.