### PR TITLE
Exe uploader service

### DIFF
--- a/config.template/faf-java-api/faf-java-api.env
+++ b/config.template/faf-java-api/faf-java-api.env
@@ -64,3 +64,6 @@ STEAM_LINK_ERROR_URL=http://localhost:8020/error?code=%s
 STEAM_LINK_REDIRECT_URL=http://localhost:8010/users/linkToSteam?token=%s
 STEAM_LINK_SUCCESS_URL=http://localhost:8020/linked_to_steam
 TUTORIAL_THUMBNAIL_URL_FORMAT=https://localhost:8091/faf/tutorials/thumbs/%s
+TESTING_EXE_UPLOAD_KEY=banana
+EXE_UPLOAD_BETA_PATH=/content/legacy-featured-mod-files/updates_fafbeta_files
+EXE_UPLOAD_DEVELOP_PATH=/content/legacy-featured-mod-files/updates_fafdevelop_files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,7 +238,7 @@ services:
   #
   faf-java-api:
     container_name: faf-java-api
-    image: faforever/faf-java-api:v2.3.1
+    image: faforever/faf-java-api:v2.4.0
     user: ${FAF_JAVA_API_USER}
     networks:
       faf:


### PR DESCRIPTION
This PR depends on https://github.com/FAForever/faf-java-api/pull/328.

We can discuss if we should move https://github.com/norraxx/faf-exe-upload under FAForever, I'll give access and rights for migration.