### PR TITLE
Enable gzip compression at Traefik for many services

### DIFF
--- a/config.template/faf-traefik/config.yml
+++ b/config.template/faf-traefik/config.yml
@@ -23,6 +23,8 @@ http:
     redirect:
       redirectScheme:
         scheme: https
+    test-compress:
+      compress: {}
 
 # Hardened TLS options by default. 
 tls:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,6 +293,7 @@ services:
       - "traefik.http.routers.faf-website.rule=Host(`www.${DOMAINNAME}`) || Host(`${DOMAINNAME}`) || Host(`clans.${DOMAINNAME}`)"
       - "traefik.http.routers.faf-website.entryPoints=web-secure"
       - "traefik.http.routers.faf-website.tls.certresolver=default"
+      - "traefik.http.routers.faf-website.middlewares=test-compress@file"
       - "traefik.http.services.faf-website.loadbalancer.server.port=3000"
     logging:
       driver: "json-file"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -653,11 +653,11 @@ services:
     env_file: ./config/faf-unitdb/faf-unitdb.env
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.faf-unitdb.rule=Host(`unitdb.${DOMAINNAME}`) || Host(`direct.${DOMAINNAME}`) && PathPrefix(`/faf/unitsDB/`)"
+      - "traefik.http.routers.faf-unitdb.rule=Host(`unitdb.${DOMAINNAME}`) || Host(`direct.${DOMAINNAME}`) && PathPrefix(`/faf/unitsDB`)"
       - "traefik.http.routers.faf-unitdb.entryPoints=web-secure"
       - "traefik.http.routers.faf-unitdb.middlewares=unitdb-stripprefix, test-compress@file"
       - "traefik.http.routers.faf-unitdb.tls.certresolver=default"
-      - "traefik.http.middlewares.unitdb-stripprefix.stripprefix.prefixes=/faf/unitsDB/"
+      - "traefik.http.middlewares.unitdb-stripprefix.stripprefix.prefixes=/faf/unitsDB"
 
     logging:
       driver: "json-file"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,6 +260,7 @@ services:
       - "traefik.http.routers.faf-java-api.rule=Host(`api.${DOMAINNAME}`)"
       - "traefik.http.routers.faf-java-api.entryPoints=web-secure"
       - "traefik.http.routers.faf-java-api.tls.certresolver=default"
+      - "traefik.http.routers.faf-java-api.middlewares=test-compress@file"
       - "traefik.http.services.faf-java-api.loadbalancer.server.port=8010"
     # TODO move to Dockerfile
     healthcheck:
@@ -505,6 +506,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.faf-phpbb3.rule=Host(`forums.${DOMAINNAME}`)"
       - "traefik.http.routers.faf-phpbb3.entryPoints=web-secure"
+      - "traefik.http.routers.faf-phpbb3.middlewares=test-compress@file"
       - "traefik.http.routers.faf-phpbb3.tls.certresolver=default"
     logging:
       driver: "json-file"
@@ -532,7 +534,7 @@ services:
       - "traefik.http.routers.faf-content.rule=Host(`content.${DOMAINNAME}`) || Host(`replay.${DOMAINNAME}`)"
       - "traefik.http.routers.faf-content.entryPoints=web-secure"
       - "traefik.http.routers.faf-content.tls.certresolver=default"
-      - "traefik.http.routers.faf-content.middlewares=faf-content-regex"
+      - "traefik.http.routers.faf-content.middlewares=faf-content-regex, test-compress@file"
       - "traefik.http.middlewares.faf-content-regex.redirectregex.regex=^(http|https)://replay.${DOMAINNAME}/(.*)"
       - "traefik.http.middlewares.faf-content-regex.redirectregex.replacement=$${1}://content.${DOMAINNAME}/faf/vault/replay_vault/replay.php?id=$${2}"
     logging:
@@ -651,14 +653,12 @@ services:
     env_file: ./config/faf-unitdb/faf-unitdb.env
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.faf-unitdb.rule=Host(`unitdb.${DOMAINNAME}`)"
+      - "traefik.http.routers.faf-unitdb.rule=Host(`unitdb.${DOMAINNAME}`) || Host(`direct.${DOMAINNAME}`) && PathPrefix(`/faf/unitsDB/`)"
       - "traefik.http.routers.faf-unitdb.entryPoints=web-secure"
+      - "traefik.http.routers.faf-unitdb.middlewares=unitdb-stripprefix, test-compress@file"
       - "traefik.http.routers.faf-unitdb.tls.certresolver=default"
-      - "traefik.http.routers.faf-unitdb-2.rule=Host(`direct.${DOMAINNAME}`) && PathPrefix(`/faf/unitsDB/`)"
-      - "traefik.http.routers.faf-unitdb-2.entryPoints=web-secure"
-      - "traefik.http.routers.faf-unitdb-2.tls.certresolver=default"
-      - "traefik.http.routers.faf-unitdb-2.middlewares=unitdb-stripprefix"
       - "traefik.http.middlewares.unitdb-stripprefix.stripprefix.prefixes=/faf/unitsDB/"
+
     logging:
       driver: "json-file"
       options:
@@ -763,6 +763,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.faf-voting.rule=Host(`voting.${DOMAINNAME}`)"
       - "traefik.http.routers.faf-voting.entryPoints=web-secure"
+      - "traefik.http.routers.faf-voting.middlewares=test-compress@file"
       - "traefik.http.routers.faf-voting.tls.certresolver=default"
       - "traefik.http.services.faf-voting.loadbalancer.server.port=3000"
     logging:


### PR DESCRIPTION
Should improve performance.

The magic line can be added to other services that are not being good webservers and are not compressing what they send. 