### PR TITLE
#394 - Solr docker config to support search function

### DIFF
--- a/config.template/faf-solr/faf-solr.env
+++ b/config.template/faf-solr/faf-solr.env
@@ -1,0 +1,4 @@
+name=search
+config=solrconfig.xml
+schema=schema.xml
+dataDir=/var/solr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -831,17 +831,20 @@ services:
   # FAF Solr standalone server
   #
   faf-solr:
-    # version: '3'
     container_name: faf-solr
-    image: solr:8
+    image: solr:8.7-slim
     ports:
       - "8983:8983"
+    env_file: ./config/faf-solr/faf-solr.env
     volumes:
       - ./data/faf-solr:/var/solr
-      - ./config/faf-solr/config.json:/usr/src/app/config.json
+    networks:
+      faf:
+        aliases:
+          - "faf-solr"
     command:
       - solr-precreate
-      - gettingstarted
+      - faf-search
 
 networks:
   faf:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -827,6 +827,22 @@ services:
         max-size: "${DEFAULT_LOG_SIZE}"
         max-file: "${HIGH_PRIO_LOG_FILES}"
 
+  #
+  # FAF Solr standalone server
+  #
+  faf-solr:
+    # version: '3'
+    container_name: faf-solr
+    image: solr:8
+    ports:
+      - "8983:8983"
+    volumes:
+      - ./data/faf-solr:/var/solr
+      - ./config/faf-solr/config.json:/usr/src/app/config.json
+    command:
+      - solr-precreate
+      - gettingstarted
+
 networks:
   faf:
     driver: bridge


### PR DESCRIPTION
This is based on this image: https://github.com/docker-solr/docker-solr. The yml was complaining on the version so commented it out. Being new to Solr I'm not fully sure how configuration is set up. 

The doc says something along the lines of that config is stored at "/etc/default/solr". Wondering whether we add copy over some config or default config is enough.

I need feedback whether correctly defined host-mounted data directory: ./data/faf-solr:/var/solr  

When I run this using the compose command: docker-compose up -d faf-solr
I come across this error: ERROR: Couldn't find env file: /home/ahsanbagwan/IdeaProjects/faf-stack/config/faf-mongodb/faf-mongodb.env which I think is not related to solr config.