### PR TITLE
Add faf-rust-replayserver

### DIFF
--- a/config.template/faf-rust-replayserver/faf-rust-replayserver.env
+++ b/config.template/faf-rust-replayserver/faf-rust-replayserver.env
@@ -1,0 +1,3 @@
+RS_CONFIG_FILE=/config/faf-rust-replayserver.yml
+RS_DB_PASSWORD=banana
+RUST_LOG=info

--- a/config.template/faf-rust-replayserver/faf-rust-replayserver.yml
+++ b/config.template/faf-rust-replayserver/faf-rust-replayserver.yml
@@ -1,0 +1,21 @@
+# See faf-rust-replayserver repository, docs/usage.rst for documentation.
+server:
+    port: 15000
+    prometheus_port: 8011
+    worker_threads: 4
+    connection_accept_timeout_s: 21600
+database:
+    pool_size: 8
+    host: faf-db
+    port: 3306
+    user: faf-aio-replayserver
+    name: faf
+storage:
+    vault_path: /content/faf/vault/replay_vault
+replay:
+    forced_timeout_s: 18000
+    time_with_zero_writers_to_end_replay_s: 30
+    delay_s: 300
+    update_interval_ms: 1000
+    merge_quorum_size: 2
+    stream_comparison_distance_b: 4096

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -539,6 +539,28 @@ services:
         max-size: "${DEFAULT_LOG_SIZE}"
         max-file: "${DEFAULT_LOG_FILES}"
 
+  # The third version of the "live replay" server, in Rust.
+  faf-rust-replayserver:
+    container_name: faf-rust-replayserver
+    image: faforever/faf-rust-replayserver:0.2.3
+    user: ${FAF_AIO_REPLAYSERVER_USER}
+    restart: unless-stopped
+    volumes:
+      - ./data/content:/content
+      - ./config/faf-rust-replayserver:/config
+    networks:
+      - faf
+    depends_on:
+      - faf-init-volumes
+    env_file: ./config/faf-rust-replayserver/faf-rust-replayserver.env
+    ports:
+      - "15000:15000"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "${DEFAULT_LOG_SIZE}"
+        max-file: "${DEFAULT_LOG_FILES}"
+
   faf-policy-server:
     container_name: faf-policy-server
     image: faforever/faf-policy-server:v1.21


### PR DESCRIPTION
The rust replay server should be ready for some testing on the test server. Here's the faf-stack stuff for it. I changed the DB user since current name isn't really generic, this should be the last time.

Signed-off-by: Igor Kotrasinski <i.kotrasinsk@gmail.com>