### PR TITLE
Update faf-nodebb to v1.16.2 and faf-mongodb to 4.2.13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -712,7 +712,7 @@ services:
 
   faf-mongodb:
     container_name: faf-mongodb
-    image: mongo:4.2.9
+    image: mongo:4.2.13
     user: ${FAF_MONGODB_USER}
     restart: unless-stopped
     networks:
@@ -731,7 +731,7 @@ services:
   faf-nodebb:
     # for instructions how to initialize the setup check the readme in the config.template/faf-nodebb
     container_name: faf-nodebb
-    image: nodebb/docker:v1.14.3
+    image: nodebb/docker:v1.16.2
     user: ${FAF_NODEBB_USER}
     restart: unless-stopped
     env_file: ./config/faf-nodebb/faf-nodebb.env


### PR DESCRIPTION
Deployment actions:

- zfs snapshot tank/mongodb@nodebb-update
- docker-compose stop faf-mongodb faf-nodebb
- docker-compose up -d faf-mongodb
- docker-compose run faf-nodebb bash
- ./nodebb upgrade
- docker-compose up -d faf-nodebb