### PR TITLE
Update replay server to 1.1.4

### DIFF
--- a/config.template/faf-aio-replayserver/faf-aio-replayserver.yml
+++ b/config.template/faf-aio-replayserver/faf-aio-replayserver.yml
@@ -4,6 +4,7 @@ rs:
         port: "15000"
         prometheus_port: "8011"
         connection_header_read_timeout: "21600"
+        connection_linger_time: "60"
     db:
         host: faf-db
         port: "3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -256,7 +256,7 @@ services:
   #
   faf-aio-replayserver:
     container_name: faf-aio-replayserver
-    image: faforever/faf-aio-replayserver:1.1.3
+    image: faforever/faf-aio-replayserver:1.1.4
     user: ${FAF_AIO_REPLAYSERVER_USER}
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Add an option to keep the connection open for some time after sending all data. I hope this fixes the elusive short live replay bug,