### PR TITLE
Bump league service version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -374,7 +374,7 @@ services:
   #
   faf-league-service:
     container_name: faf-league-service
-    image: faforever/faf-league-service:0.1.5
+    image: faforever/faf-league-service:0.1.7
     user: ${FAF_LEAGUE_SERVICE_USER}
     networks:
       faf:


### PR DESCRIPTION
Is bumping the version number required for deploying a newer version? If not, it is maybe less effort if wait with this pr until version 1.0 is out in a few weeks and bump it directly to 1.0