### PR TITLE
bump faf-rust-replayserver to 0.3.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -285,7 +285,7 @@ services:
   # The third version of the "live replay" server, in Rust.
   faf-rust-replayserver:
     container_name: faf-rust-replayserver
-    image: faforever/faf-rust-replayserver:0.3.1
+    image: faforever/faf-rust-replayserver:0.3.2
     user: ${FAF_AIO_REPLAYSERVER_USER}
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Fixes some bugs found after last deployment.