### PR TITLE
Minor improvements to init scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,15 @@ Hint: Some linux distros generate 3072 bit RSA keys by default (e.g. Arch). 3072
 
     scripts/init-all.sh
 
-This will launch some core services and generate users, database schemas and OAuth clients.
+This will launch some core services and generate system users, database schemas and OAuth clients.
+
+### Load test data
+
+After initialization you will have a blank database - no logins, no maps, etc. In all likelihood you'd like to load some data to use this environment. You could look at the [test data](https://github.com/FAForever/db/blob/develop/test-data.sql), the [sanitized db dump](https://github.com/FAForever/faf-db-dump/tree/2294e41bae36acaed4a52c8a7d090ddd76001a25) or [API server integration test data](https://github.com/FAForever/faf-java-api/tree/develop/src/inttest/resources/sql). Each of these has pros and cons and commonly becomes stale (as schema evolves etc), and you may need to fiddle with data to match new schemas; database repository history may help.
+
+To load the data, you'd run a command along the lines of -
+
+    docker exec -i  faf-db mysql -D faf -uroot -pbanana < $DB_REPO/test-data.sql
 
 ### Update database schema
 

--- a/README.md
+++ b/README.md
@@ -67,14 +67,13 @@ Hint: Some linux distros generate 3072 bit RSA keys by default (e.g. Arch). 3072
 
 ### Initialize core services
 
-    scripts/init-db.sh
-    scripts/init-rabbitmq.sh
-    scripts/init-hydra.sh
-    scripts/create-hydra-test-clients.sh
+    scripts/init-all.sh
 
 This will launch some core services and generate users, database schemas and OAuth clients.
 
 ### Update database schema
+
+If new migrations were added since you've initialized your environment, you can run them with -
 
     docker-compose run --rm faf-db-migrations migrate
 

--- a/config.template/faf-java-api/faf-java-api.env
+++ b/config.template/faf-java-api/faf-java-api.env
@@ -58,3 +58,4 @@ TUTORIAL_THUMBNAIL_URL_FORMAT=http://localhost:8091/faf/tutorials/thumbs/%s
 TESTING_EXE_UPLOAD_KEY=banana
 EXE_UPLOAD_BETA_PATH=/content/legacy-featured-mod-files/updates_fafbeta_files
 EXE_UPLOAD_DEVELOP_PATH=/content/legacy-featured-mod-files/updates_fafdevelop_files
+JWT_FAF_HYDRA_ISSUER=http://faf-ory-hydra:4444/

--- a/config.template/faf-python-server/dynamic/config.yml
+++ b/config.template/faf-python-server/dynamic/config.yml
@@ -4,7 +4,7 @@ LOG_LEVEL: "TRACE"
 DB_SERVER: "faf-db"
 DB_LOGIN: "faf-python-server"
 DB_PASSWORD: "banana"
-DB_NAME: "faf_lobby"
+DB_NAME: "faf"
 
 MQ_SERVER: "faf-rabbitmq"
 MQ_PORT: 5672
@@ -18,10 +18,13 @@ ENABLE_METRICS: true
 COTURN_HOSTS: ["test.faforever.com"]
 COTURN_KEYS: ["banana"]
 
-FAF_POLICY_SERVER_BASE_URL: "http://faf-policy-server:8097"
+USE_POLICY_SERVER: false
+#FAF_POLICY_SERVER_BASE_URL: "http://faf-policy-server:8097"
 
 FORCE_STEAM_LINK: false
 # Seconds since epoch
 FORCE_STEAM_LINK_AFTER_DATE: 0
 
 QUEUE_POP_TIME_MAX: 60
+
+HYDRA_JWKS_URI: "http://faf-ory-hydra:4444/.well-known/jwks.json"

--- a/scripts/create-hydra-test-clients.sh
+++ b/scripts/create-hydra-test-clients.sh
@@ -5,6 +5,21 @@ if [ ! -f docker-compose.yml ]; then
     exit 1
 fi
 
+MAX_WAIT=60 # max. 1 minute waiting time in loop before timeout
+
+echo -n "Waiting for hydra clients list "
+current_wait=0
+while ! docker-compose exec faf-ory-hydra hydra clients list --endpoint http://127.0.0.1:4445 >/dev/null 2>&1
+do
+  if [ ${current_wait} -ge ${MAX_WAIT} ]; then
+    echo "Timeout on listing hydra clients"
+    exit 1
+  fi
+  current_wait=$((current_wait+1))
+  sleep 1
+done
+echo ok
+
 docker-compose exec faf-ory-hydra hydra clients create \
     --skip-tls-verify \
     --endpoint http://127.0.0.1:4445 \

--- a/scripts/init-all.sh
+++ b/scripts/init-all.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [ ! -f docker-compose.yml ]; then
+    echo "You are not inside faf-stack! The working directory must be the root of faf-stack."
+    exit 1
+fi
+
+[ ! -d config ] && ln -s config.template config
+[ ! -f .env ] && ln -s .env.template .env
+
+echo "initializing database"
+scripts/init-db.sh
+echo "initializing rabbitmq"
+scripts/init-rabbitmq.sh
+echo "initializing hydra"
+scripts/init-hydra.sh
+echo "creating hydra test clients"
+sleep 0.1
+scripts/create-hydra-test-clients.sh

--- a/scripts/init-all.sh
+++ b/scripts/init-all.sh
@@ -5,8 +5,14 @@ if [ ! -f docker-compose.yml ]; then
     exit 1
 fi
 
-[ ! -d config ] && ln -s config.template config
-[ ! -f .env ] && ln -s .env.template .env
+if [ ! -d config ]; then
+    echo "NOTE: symlinking config.template into config (make a copy to make local changes)"
+    ln -s config.template config
+fi
+if [ ! -f .env ]; then
+    echo "NOTE: symlinking .env.template into .env (make a copy to make local changes)"
+    ln -s .env.template .env
+fi
 
 echo "initializing database"
 scripts/init-db.sh

--- a/scripts/init-rabbitmq.sh
+++ b/scripts/init-rabbitmq.sh
@@ -14,6 +14,19 @@ docker-compose up -d faf-rabbitmq
 # Create RabbitMQ users
 docker-compose exec faf-rabbitmq rabbitmqctl wait --timeout ${MAX_WAIT} "${RABBITMQ_PID_FILE}"
 
+echo -n "Waiting for rabbitmq status "
+current_wait=0
+while ! docker-compose exec faf-rabbitmq rabbitmqctl status >/dev/null 2>&1
+do
+  if [ ${current_wait} -ge ${MAX_WAIT} ]; then
+    echo "Timeout on startup of rabbitmq"
+    exit 1
+  fi
+  current_wait=$((current_wait+1))
+  sleep 1
+done
+echo ok
+
 docker-compose exec faf-rabbitmq rabbitmqctl add_vhost "${RABBITMQ_FAF_VHOST}"
 docker-compose exec faf-rabbitmq rabbitmqctl add_user "${RABBITMQ_FAF_LOBBY_USER}" "${RABBITMQ_FAF_LOBBY_PASS}"
 docker-compose exec faf-rabbitmq rabbitmqctl set_permissions -p "${RABBITMQ_FAF_VHOST}" "${RABBITMQ_FAF_LOBBY_USER}" ".*" ".*" ".*"


### PR DESCRIPTION
This PR introduces the script `init-all.sh` which doesn't do much other than run the scripts in order.

It also fixes two race conditions/insufficient polling in the rabbitmq and hydra init scripts (the race is more likely to be "lost" when init scripts are run quickly from a master scripts).

This PR is minor, but I think it's a net-positive improvement, and it's part of laying the groundwork to more extensive revision of `faf-stack` to better support dev environments.